### PR TITLE
use lodepng

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,8 @@
   },
   "dependencies": {
     "color-diff": "^0.1.5",
-    "concat-stream": "^1.5.0",
-    "parse-color": "^1.0.0",
-    "pngjs": "^0.4.0",
-    "pngparse": "^2.0.1"
+    "lodepng": "^0.2.0",
+    "parse-color": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
This pull request replaces `concat-stream`, `pngjs` and `pngparse` with the one dependency `lodepng`. It also simplifies the code.

The tests are running a bit faster 0.11s instead of 0.14-0.15s, but this is *very non scientifically*. I haven't done any proper benchmarking.

It also gets rid of the following warning that was printed every time I installed looks-same :+1: 

> npm WARN engine pngjs@0.4.0: wanted: {"node":"0.8.x"} (current: {"node":"5.0.0","npm":"3.3.9"})