### PR TITLE
feat: add ability to ingore antialising and caret in "createDiff" method

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,13 @@ looksSame.createDiff({
     reference: '/path/to/reference/image.png',
     current: '/path/to/current/image.png',
     diff: '/path/to/save/diff/to.png',
-    highlightColor: '#ff00ff', //color to highlight the differences
-    strict: false,//strict comparsion
-    tolerance: 2.5
+    highlightColor: '#ff00ff', // color to highlight the differences
+    strict: false, // strict comparsion
+    tolerance: 2.5,
+    ignoreAntialiasing: false, // do not ignore antialising by default
+    ignoreCaret: false // do not ignore caret by default
 }, function(error) {
+    ...
 });
 ```
 
@@ -108,7 +111,7 @@ receive a `Buffer` containing the diff as the 2nd argument.
 
 ```javascript
 looksSame.createDiff({
-    //exactly same options as above, but without diff
+    // exactly same options as above, but without diff
 }, function(error, buffer) {
     ...
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,11 +65,19 @@ interface CreateDiffAsBufferOptions {
     /**
      * strict comparsion
      */
-    strict: boolean;
+    strict?: boolean;
     /**
      * ΔE value that will be treated as error in non-strict mode
      */
-    tolerance: number;
+    tolerance?: number;
+    /**
+     * Ability to ignore antialiasing
+     */
+    ignoreAntialiasing?: boolean;
+    /**
+     * Ability to ignore text caret
+     */
+    ignoreCaret?: false;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ const buildDiffImage = (png1, png2, options, callback) => {
         const color1 = png1.getPixel(x, y);
         const color2 = png2.getPixel(x, y);
 
-        if (!options.comparator({color1, color2})) {
+        if (!options.comparator({color1, color2, png1, png2, x, y, width, height})) {
             result.setPixel(x, y, highlightColor);
         } else {
             result.setPixel(x, y, color1);
@@ -213,19 +213,19 @@ exports.getDiffArea = function(reference, image, opts, callback) {
 };
 
 exports.createDiff = function saveDiff(opts, callback) {
-    const tolerance = getToleranceFromOpts(opts);
+    opts.tolerance = getToleranceFromOpts(opts);
 
-    readPair(opts.reference, opts.current, (error, result) => {
+    readPair(opts.reference, opts.current, (error, {first, second}) => {
         if (error) {
             return callback(error);
         }
 
         const diffOptions = {
             highlightColor: parseColorString(opts.highlightColor),
-            comparator: opts.strict ? areColorsSame : makeCIEDE2000Comparator(tolerance)
+            comparator: createComparator(first, second, opts)
         };
 
-        buildDiffImage(result.first, result.second, diffOptions, (result) => {
+        buildDiffImage(first, second, diffOptions, (result) => {
             if (opts.diff === undefined) {
                 result.createBuffer(callback);
             } else {

--- a/lib/antialiasing-comparator.js
+++ b/lib/antialiasing-comparator.js
@@ -8,7 +8,7 @@
 const DEFAULT_BRIGHTNESS_TOLERANCE = 0;
 
 module.exports = class AntialiasingComparator {
-    constructor(baseComparator, png1, png2, {antialiasingTolerance}) {
+    constructor(baseComparator, png1, png2, {antialiasingTolerance = 0}) {
         this._baseComparator = baseComparator;
         this._img1 = png1;
         this._img2 = png2;

--- a/test/test.js
+++ b/test/test.js
@@ -269,7 +269,7 @@ describe('createDiff', () => {
         });
     });
 
-    it('should create an image file a diff for for two images', (done) => {
+    it('should create an image file with diff between two images', (done) => {
         const _this = this;
         looksSame.createDiff({
             reference: srcPath('ref.png'),
@@ -410,6 +410,146 @@ describe('createDiff', () => {
                 expect(equal).to.be.equal(true);
                 done();
             });
+        });
+    });
+
+    describe('with antialiasing', () => {
+        describe('if there is only diff in antialiased pixels', () => {
+            it('should create diff image not equal to reference if ignore antialiasing is not set', (done) => {
+                looksSame.createDiff({
+                    reference: srcPath('antialiasing-ref.png'),
+                    current: srcPath('antialiasing-actual.png'),
+                    diff: this.tempName,
+                    highlightColor: '#FF00FF'
+                }, () => {
+                    looksSame(
+                        srcPath('antialiasing-ref.png'), this.tempName, {ignoreAntialiasing: false},
+                        (error, equal) => {
+                            expect(error).to.equal(null);
+                            expect(equal).to.equal(false);
+                            done();
+                        }
+                    );
+                });
+            });
+
+            it('should create diff image equal to reference if ignore antialiasing is disabled', (done) => {
+                looksSame.createDiff({
+                    reference: srcPath('antialiasing-ref.png'),
+                    current: srcPath('antialiasing-actual.png'),
+                    diff: this.tempName,
+                    highlightColor: '#FF00FF',
+                    ignoreAntialiasing: true
+                }, () => {
+                    looksSame(
+                        srcPath('antialiasing-ref.png'), this.tempName, {ignoreAntialiasing: false},
+                        (error, equal) => {
+                            expect(error).to.equal(null);
+                            expect(equal).to.equal(true);
+                            done();
+                        }
+                    );
+                });
+            });
+        });
+
+        it('should create diff image not equal to reference if there is diff not in antialised pixels', (done) => {
+            looksSame.createDiff({
+                reference: srcPath('no-caret.png'),
+                current: srcPath('1px-diff.png'),
+                diff: this.tempName,
+                highlightColor: '#FF00FF',
+                ignoreAntialiasing: true
+            }, () => {
+                looksSame(
+                    srcPath('antialiasing-ref.png'), this.tempName,
+                    (error, equal) => {
+                        expect(error).to.equal(null);
+                        expect(equal).to.equal(false);
+                        done();
+                    }
+                );
+            });
+        });
+    });
+
+    describe('with ignoreCaret', () => {
+        describe('if there is only diff in caret', () => {
+            it('should create diff image not equal to reference if ignore caret is not set', (done) => {
+                looksSame.createDiff({
+                    reference: srcPath('no-caret.png'),
+                    current: srcPath('caret.png'),
+                    diff: this.tempName,
+                    highlightColor: '#FF00FF'
+                }, () => {
+                    looksSame(
+                        srcPath('no-caret.png'), this.tempName,
+                        (error, equal) => {
+                            expect(error).to.equal(null);
+                            expect(equal).to.equal(false);
+                            done();
+                        }
+                    );
+                });
+            });
+
+            it('should create diff image equal to reference if ignore caret is disabled', (done) => {
+                looksSame.createDiff({
+                    reference: srcPath('no-caret.png'),
+                    current: srcPath('caret.png'),
+                    diff: this.tempName,
+                    highlightColor: '#FF00FF',
+                    ignoreCaret: true
+                }, () => {
+                    looksSame(
+                        srcPath('no-caret.png'), this.tempName,
+                        (error, equal) => {
+                            expect(error).to.equal(null);
+                            expect(equal).to.equal(true);
+                            done();
+                        }
+                    );
+                });
+            });
+        });
+
+        it('should create diff image not equal to reference if there is diff not in caret', (done) => {
+            looksSame.createDiff({
+                reference: srcPath('no-caret.png'),
+                current: srcPath('1px-diff.png'),
+                diff: this.tempName,
+                highlightColor: '#FF00FF',
+                ignoreCaret: true
+            }, () => {
+                looksSame(
+                    srcPath('no-caret.png'), this.tempName,
+                    (error, equal) => {
+                        expect(error).to.equal(null);
+                        expect(equal).to.equal(false);
+                        done();
+                    }
+                );
+            });
+        });
+    });
+
+    it('should create diff image equal to reference if there are diff in antialised pixels and caret', (done) => {
+        looksSame.createDiff({
+            reference: srcPath('caret+antialiasing.png'),
+            current: srcPath('no-caret+antialiasing.png'),
+            diff: this.tempName,
+            highlightColor: '#FF00FF',
+            ignoreAntialiasing: true,
+            ignoreCaret: true
+        }, () => {
+            looksSame(
+                srcPath('caret+antialiasing.png'), this.tempName, {ignoreAntialiasing: false},
+                (error, equal) => {
+                    expect(error).to.equal(null);
+                    expect(equal).to.equal(true);
+                    done();
+                }
+            );
         });
     });
 });


### PR DESCRIPTION
~~Currently "createDiff" method compares images without ignoring antialising and caret. Although the main method of looks-same compares images with their ignoring. I fixed it.~~