### PR TITLE
feat: add diff clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,18 @@ looksSame('image1.png', 'image2.png', {ignoreAntialiasing: true, antialiasingTol
 ### Getting diff bounds
 Looksame returns information about diff bounds. It returns only first pixel if you passed `stopOnFirstFail` option with `true` value. The whole diff area would be returned if `stopOnFirstFail` option is not passed or it's passed with `false` value.
 
+### Getting diff clusters
+Looksame returns diff bounds divided into clusters. You can pass clusters size using `clustersSize` option.
+
 ```javascript
-looksSame('image1.png', 'image2.png', {stopOnFirstFail: false}, function(error, {equal, diffBounds}) {
+looksSame('image1.png', 'image2.png', {stopOnFirstFail: false}, function(error, {equal, diffBounds, diffClusters}) {
     // {
     //     equal: false,
     //     diffBounds: {left: 10, top: 10, right: 20, bottom: 20}
+    //     diffClusters: [
+    //         {left: 10, top: 10, right: 14, bottom: 14},
+    //         {left: 16, top: 16, right: 20, bottom: 20}
+    //     ]
     // }
 });
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,10 @@ interface LooksSameResult {
      * diff bounds for not equal images
      */
     diffBounds?: CoordBounds;
+    /**
+     * diff clusters for not equal images
+     */
+    diffClusters?: CoordBounds[];
 }
 
 type LooksSameCallback = (error: Error | null, result: LooksSameResult) => void;
@@ -100,6 +104,14 @@ interface LooksSameOptions {
      * Diff bounds will contain the whole diff if stopOnFirstFail is false and only first diff pixel - otherwise.
      */
     stopOnFirstFail?: boolean;
+    /**
+     * Responsible for diff bounds clustering
+     */
+    shouldCluster?: boolean;
+    /**
+     * Radius for every diff cluster
+     */
+    clustersSize?: number;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -159,12 +159,12 @@ module.exports = exports = function looksSame(image1, image2, opts, callback) {
         }
 
         const comparator = createComparator(first, second, opts);
-        const {stopOnFirstFail} = opts;
+        const {stopOnFirstFail, shouldCluster, clustersSize} = opts;
 
-        getDiffPixelsCoords(first, second, comparator, {stopOnFirstFail}, (result) => {
-            const diffBounds = result.area;
+        getDiffPixelsCoords(first, second, comparator, {stopOnFirstFail, shouldCluster, clustersSize}, ({diffArea, diffClusters}) => {
+            const diffBounds = diffArea.area;
 
-            callback(null, {equal: result.isEmpty(), metaInfo, diffBounds});
+            callback(null, {equal: diffArea.isEmpty(), metaInfo, diffBounds, diffClusters});
         });
     });
 };
@@ -191,12 +191,12 @@ exports.getDiffArea = function(image1, image2, opts, callback) {
 
         const comparator = createComparator(first, second, opts);
 
-        getDiffPixelsCoords(first, second, comparator, opts, (result) => {
-            if (result.isEmpty()) {
+        getDiffPixelsCoords(first, second, comparator, opts, ({diffArea}) => {
+            if (diffArea.isEmpty()) {
                 return callback(null, null);
             }
 
-            callback(null, result.area);
+            callback(null, diffArea.area);
         });
     });
 };

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,5 +3,6 @@
 module.exports = {
     JND: 2.3, // Just noticeable difference if ciede2000 >= JND then colors difference is noticeable by human eye
     REQUIRED_IMAGE_FIELDS: ['source', 'boundingBox'],
-    REQUIRED_BOUNDING_BOX_FIELDS: ['left', 'top', 'right', 'bottom']
+    REQUIRED_BOUNDING_BOX_FIELDS: ['left', 'top', 'right', 'bottom'],
+    CLUSTERS_SIZE: 10
 };

--- a/lib/diff-area.js
+++ b/lib/diff-area.js
@@ -1,6 +1,10 @@
 'use strict';
 
 module.exports = class DiffArea {
+    static create() {
+        return new DiffArea();
+    }
+
     constructor() {
         this._diffArea = {left: Infinity, top: Infinity, right: -Infinity, bottom: -Infinity};
         this._updated = false;
@@ -16,6 +20,14 @@ module.exports = class DiffArea {
             bottom: Math.max(bottom, y)
         };
         this._updated = true;
+
+        return this;
+    }
+
+    isPointInArea(x, y, radius) {
+        const {left, top, right, bottom} = this._diffArea;
+
+        return x >= (left - radius) && x <= (right + radius) && y >= (top - radius) && y <= (bottom + radius);
     }
 
     isEmpty() {

--- a/lib/diff-clusters/clusters-joiner.js
+++ b/lib/diff-clusters/clusters-joiner.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const DiffArea = require('../diff-area');
+const jsgraphs = require('js-graph-algorithms');
+
+const hasOverlap = (cluster1, cluster2) => {
+    if (cluster1.left > cluster2.right || cluster2.left > cluster1.right) {
+        return false;
+    }
+
+    if (cluster1.bottom < cluster2.top || cluster2.bottom < cluster1.top) {
+        return false;
+    }
+
+    return true;
+};
+
+const getConnectedComponents = (clusters) => {
+    const graph = new jsgraphs.Graph(clusters.length);
+
+    clusters.forEach((c1, i) => {
+        clusters.forEach((c2, j) => {
+            if (i !== j && hasOverlap(c1.area, c2.area)) {
+                graph.addEdge(i, j);
+            }
+        });
+    });
+
+    return new jsgraphs.ConnectedComponents(graph);
+};
+
+exports.join = (clusters) => {
+    const connectedComponents = getConnectedComponents(clusters);
+
+    return connectedComponents.id.reduce((acc, clusterId, i) => {
+        const {left, top, right, bottom} = clusters[i].area;
+        if (!acc[clusterId]) {
+            acc[clusterId] = DiffArea.create();
+        }
+
+        acc[clusterId]
+            .update(left, top)
+            .update(right, bottom);
+
+        return acc;
+    }, []);
+};

--- a/lib/diff-clusters/index.js
+++ b/lib/diff-clusters/index.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const DiffArea = require('../diff-area');
+const {CLUSTERS_SIZE} = require('../constants');
+const clustersJoiner = require('./clusters-joiner');
+
+module.exports = class DiffClusters {
+    constructor(clustersSize) {
+        this._clustersSize = clustersSize || CLUSTERS_SIZE;
+        this._clusters = [];
+    }
+
+    update(x, y) {
+        if (!this._clusters.length) {
+            this._clusters.push(DiffArea.create().update(x, y));
+
+            return;
+        }
+
+        this._joinToClusters(x, y);
+
+        return this;
+    }
+
+    _joinToClusters(x, y) {
+        const pointCluster = this._clusters.find((c) => c.isPointInArea(x, y, this._clustersSize));
+
+        if (!pointCluster) {
+            this._clusters.push(DiffArea.create().update(x, y));
+
+            return;
+        }
+
+        pointCluster.update(x, y);
+    }
+
+    get clusters() {
+        return clustersJoiner.join(this._clusters).map(c => c.area);
+    }
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const png = require('./png');
 const DiffArea = require('./diff-area');
+const DiffClusters = require('./diff-clusters');
 const validators = require('./validators');
 
 exports.readPair = (first, second, callback) => {
@@ -36,6 +37,10 @@ exports.readPair = (first, second, callback) => {
     });
 };
 
+const getDiffClusters = (diffClusters, diffArea, {shouldCluster}) => {
+    return shouldCluster ? diffClusters.clusters : [diffArea.area];
+};
+
 exports.getDiffPixelsCoords = (png1, png2, predicate, opts, callback) => {
     if (!callback) {
         callback = opts;
@@ -48,6 +53,7 @@ exports.getDiffPixelsCoords = (png1, png2, predicate, opts, callback) => {
     const height = Math.min(png1.height, png2.height);
 
     const diffArea = new DiffArea();
+    const diffClusters = new DiffClusters(opts.clustersSize);
 
     const processRow = (y) => {
         setImmediate(() => {
@@ -65,9 +71,12 @@ exports.getDiffPixelsCoords = (png1, png2, predicate, opts, callback) => {
                 if (!result) {
                     const {x: actX, y: actY} = png1.getActualCoord(x, y);
                     diffArea.update(actX, actY);
+                    if (opts.shouldCluster) {
+                        diffClusters.update(actX, actY);
+                    }
 
                     if (stopOnFirstFail) {
-                        return callback(diffArea);
+                        return callback({diffArea, diffClusters: getDiffClusters(diffClusters, diffArea, opts)});
                     }
                 }
             }
@@ -77,7 +86,7 @@ exports.getDiffPixelsCoords = (png1, png2, predicate, opts, callback) => {
             if (y < height) {
                 processRow(y);
             } else {
-                callback(diffArea);
+                callback({diffArea, diffClusters: getDiffClusters(diffClusters, diffArea, opts)});
             }
         });
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -936,6 +936,11 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "js-graph-algorithms": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/js-graph-algorithms/-/js-graph-algorithms-1.0.18.tgz",
+      "integrity": "sha1-+W7Ie/GU9cCjE2X6Dh0Ht7li2JE="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "color-diff": "^1.1.0",
     "concat-stream": "^1.6.2",
+    "js-graph-algorithms": "1.0.18",
     "lodash": "^4.17.3",
     "parse-color": "^1.0.0",
     "pngjs": "^3.3.3"

--- a/test/diff-area.js
+++ b/test/diff-area.js
@@ -33,4 +33,26 @@ describe('DiffArea', () => {
             expect(diffArea.isEmpty()).to.equal(false);
         });
     });
+
+    describe('isPointInArea', () => {
+        it('should return "true" if point inside of area', () => {
+            const diffArea = new DiffArea();
+
+            diffArea
+                .update(1, 1)
+                .update(5, 5);
+
+            assert.isTrue(diffArea.isPointInArea(10, 10, 10));
+        });
+
+        it('should return "false" if point is outside of area', () => {
+            const diffArea = new DiffArea();
+
+            diffArea
+                .update(1, 1)
+                .update(5, 5);
+
+            expect(diffArea.isPointInArea(20, 20, 10)).to.equal(false);
+        });
+    });
 });

--- a/test/diff-clusters/clusters-joiner.js
+++ b/test/diff-clusters/clusters-joiner.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const clustersJoiner = require('../../lib/diff-clusters/clusters-joiner');
+
+describe('DiffClusters', () => {
+    it('should join clusters', () => {
+        const clusters = [
+            {area: {left: 1, top: 1, right: 5, bottom: 5}},
+            {area: {left: 2, top: 2, right: 6, bottom: 6}},
+            {area: {left: 10, top: 10, right: 11, bottom: 11}}
+        ];
+        const joinedClusters = clustersJoiner.join(clusters).map(c => c.area);
+
+        assert.deepEqual(joinedClusters, [
+            {left: 1, top: 1, right: 6, bottom: 6},
+            {left: 10, top: 10, right: 11, bottom: 11}
+        ]);
+    });
+});

--- a/test/diff-clusters/index.js
+++ b/test/diff-clusters/index.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const DiffArea = require('../../lib/diff-area');
+const DiffClusters = require('../../lib/diff-clusters');
+const clustersJoiner = require('../../lib/diff-clusters/clusters-joiner');
+
+describe('DiffClusters', () => {
+    const sandbox = sinon.createSandbox();
+
+    beforeEach(() => {
+        sandbox.stub(clustersJoiner, 'join');
+        sandbox.stub(DiffArea.prototype, 'isPointInArea');
+    });
+
+    afterEach(() => sandbox.restore());
+
+    it('should define points to different clusters', () => {
+        DiffArea.prototype.isPointInArea.returns(false);
+        clustersJoiner.join = (clusters) => clusters;
+        const diffClusters = new DiffClusters();
+
+        diffClusters.update(1, 1);
+        diffClusters.update(5, 5);
+
+        assert.deepEqual(diffClusters.clusters, [
+            {left: 1, top: 1, right: 1, bottom: 1},
+            {left: 5, top: 5, right: 5, bottom: 5}
+        ]);
+    });
+
+    it('should define points to the same clusters', () => {
+        DiffArea.prototype.isPointInArea.returns(true);
+        clustersJoiner.join = (clusters) => clusters;
+        const diffClusters = new DiffClusters();
+
+        diffClusters.update(1, 1);
+        diffClusters.update(5, 5);
+
+        assert.deepEqual(diffClusters.clusters, [{left: 1, top: 1, right: 5, bottom: 5}]);
+    });
+
+    it('should return joined clusters', () => {
+        DiffArea.prototype.isPointInArea.returns(false);
+        clustersJoiner.join.returns([{area: {left: 1, top: 1, right: 5, bottom: 5}}]);
+        const diffClusters = new DiffClusters();
+
+        diffClusters.update(1, 1);
+        diffClusters.update(5, 5);
+
+        assert.deepEqual(diffClusters.clusters, [{left: 1, top: 1, right: 5, bottom: 5}]);
+    });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -861,8 +861,8 @@ describe('getDiffPixelsCoords', () => {
         const [img1, img2] = formatImages(srcPath('ref.png'), srcPath('different.png'));
 
         readPair(img1, img2, (error, pair) => {
-            getDiffPixelsCoords(pair.first, pair.second, areColorsSame, (result) => {
-                expect(result.area).to.deep.equal({left: 0, top: 0, right: 49, bottom: 39});
+            getDiffPixelsCoords(pair.first, pair.second, areColorsSame, ({diffArea}) => {
+                expect(diffArea.area).to.deep.equal({left: 0, top: 0, right: 49, bottom: 39});
                 done();
             });
         });
@@ -872,8 +872,8 @@ describe('getDiffPixelsCoords', () => {
         const [img1, img2] = formatImages(srcPath('ref.png'), srcPath('different.png'));
 
         readPair(img1, img2, (error, pair) => {
-            getDiffPixelsCoords(pair.first, pair.second, areColorsSame, {stopOnFirstFail: true}, (result) => {
-                expect(result.area).to.deep.equal({left: 49, top: 0, right: 49, bottom: 0});
+            getDiffPixelsCoords(pair.first, pair.second, areColorsSame, {stopOnFirstFail: true}, ({diffArea}) => {
+                expect(diffArea.area).to.deep.equal({left: 49, top: 0, right: 49, bottom: 0});
                 done();
             });
         });


### PR DESCRIPTION
- Во время поиска диффа каждую точку относим к одному из уже существующих кластеров
- т.к. кластеризация осуществляется "налету", возможны пересечения кластеров, их нужно объединять
- Объединение кластеров - это разбиение графа на компоненты связности, для этого нашел либу `js-graph-algorithms`
- Возвращаю и diffBounds и diffClusters, чтобы api не ломать