### PR TITLE
Add support of ignore areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ looksSame.createDiff({
     strict: false, // strict comparsion
     tolerance: 2.5,
     antialiasingTolerance: 0,
-    ignoreAreasColor: '#f0ffff', // color to highlight ignored areas
     ignoreAreas: [], // list of areas to ignore, in form {top: 0, left: 0, width: 5, height: 5}
     ignoreAntialiasing: true, // ignore antialising by default
     ignoreCaret: true // ignore caret by default

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ looksSame.createDiff({
     strict: false, // strict comparsion
     tolerance: 2.5,
     antialiasingTolerance: 0,
-    ignoreColor: '#f0ffff', // color to highlight ignored areas
+    ignoreAreaColor: '#f0ffff', // color to highlight ignored areas
     ignoreAreas: [], // list of areas to ignore, in form {top: 0, left: 0, width: 5, height: 5}
     ignoreAntialiasing: true, // ignore antialising by default
     ignoreCaret: true // ignore caret by default

--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ looksSame('image1.png', 'image2.png', {ignoreAntialiasing: true, antialiasingTol
 });
 ```
 
+### Comparing images with ignoring part of area
+
+Sometimes is usefull to ignore some part of an image in comparision. Such areas could be passed as `ignoreAreas` option. Each area should be an object with `left`, `top`, `width` and `height` properties. Notice that values must be scaled appropriate to pixelRatio beforehand.
+
+Example:
+```javascript
+looksSame('image1.png', 'image2.png', {ignoreAreas: [
+        {
+            top: 0,
+            left: 5,
+            width: 100,
+            height: 50
+        }
+    ]}, function(error, {equal}) {
+    ...
+});
+```
+
 ### Getting diff bounds
 Looksame returns information about diff bounds. It returns only first pixel if you passed `stopOnFirstFail` option with `true` value. The whole diff area would be returned if `stopOnFirstFail` option is not passed or it's passed with `false` value.
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ looksSame.createDiff({
     strict: false, // strict comparsion
     tolerance: 2.5,
     antialiasingTolerance: 0,
+    ignoreColor: '#f0ffff', // color to highlight ignored areas
+    ignoreAreas: [], // list of areas to ignore, in form {top: 0, left: 0, width: 5, height: 5}
     ignoreAntialiasing: true, // ignore antialising by default
     ignoreCaret: true // ignore caret by default
 }, function(error) {

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ looksSame.createDiff({
     strict: false, // strict comparsion
     tolerance: 2.5,
     antialiasingTolerance: 0,
-    ignoreAreaColor: '#f0ffff', // color to highlight ignored areas
+    ignoreAreasColor: '#f0ffff', // color to highlight ignored areas
     ignoreAreas: [], // list of areas to ignore, in form {top: 0, left: 0, width: 5, height: 5}
     ignoreAntialiasing: true, // ignore antialising by default
     ignoreCaret: true // ignore caret by default

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ const buildDiffImage = (png1, png2, options, callback) => {
     const highlightColor = options.highlightColor;
     const result = png.empty(width, height);
     const ignoreAreas = options.ignoreAreas || [];
-    const ignoredOverlay = options.ignoreColor;
+    const ignoredOverlay = options.ignoreAreaColor;
     const blend = (a, b, k) => {
         return {
             R: a.R * k + b.R * (1 - k),
@@ -228,7 +228,7 @@ exports.createDiff = function saveDiff(opts, callback) {
 
         const diffOptions = {
             ignoreAreas: opts.ignoreAreas,
-            ignoreColor: parseColorString(opts.ignoreColor || '#f0ffff'),
+            ignoreAreaColor: parseColorString(opts.ignoreAreaColor || '#f0ffff'),
             highlightColor: parseColorString(opts.highlightColor || '#ff00ff'),
             comparator: createComparator(first, second, opts)
         };

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ const buildDiffImage = (png1, png2, options, callback) => {
     const highlightColor = options.highlightColor;
     const result = png.empty(width, height);
     const ignoreAreas = options.ignoreAreas || [];
-    const ignoredOverlay = options.ignoreAreaColor;
+    const ignoredOverlay = options.ignoreAreasColor;
     const blend = (a, b, k) => {
         return {
             R: a.R * k + b.R * (1 - k),
@@ -228,7 +228,7 @@ exports.createDiff = function saveDiff(opts, callback) {
 
         const diffOptions = {
             ignoreAreas: opts.ignoreAreas,
-            ignoreAreaColor: parseColorString(opts.ignoreAreaColor || '#f0ffff'),
+            ignoreAreasColor: parseColorString(opts.ignoreAreasColor || '#f0ffff'),
             highlightColor: parseColorString(opts.highlightColor || '#ff00ff'),
             comparator: createComparator(first, second, opts)
         };

--- a/index.js
+++ b/index.js
@@ -50,10 +50,10 @@ const createComparator = (png1, png2, opts) => {
 
 const iterateRect = (width, height, areas, callback, endCallback) => {
     const processRow = (y) => {
-        const matchedAreas = areas.filter(yInArea(y));
+        const matchedAreas = areas.filter((area) => yInArea(area, y));
         setImmediate(() => {
             for (let x = 0; x < width; x++) {
-                callback(x, y, matchedAreas.some(xInArea(x)));
+                callback(x, y, matchedAreas.some((area) => xInArea(area, x)));
             }
 
             y++;

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const areColorsSame = require('./lib/same-colors');
 const AntialiasingComparator = require('./lib/antialiasing-comparator');
 const IgnoreCaretComparator = require('./lib/ignore-caret-comparator');
 const utils = require('./lib/utils');
-const {getDiffPixelsCoords} = utils;
+const {getDiffPixelsCoords, yInArea, xInArea} = utils;
 const {JND} = require('./lib/constants');
 
 const makeAntialiasingComparator = (comparator, png1, png2, opts) => {
@@ -48,11 +48,12 @@ const createComparator = (png1, png2, opts) => {
     return comparator;
 };
 
-const iterateRect = (width, height, callback, endCallback) => {
+const iterateRect = (width, height, areas, callback, endCallback) => {
     const processRow = (y) => {
+        const matchedAreas = areas.filter(yInArea(y));
         setImmediate(() => {
             for (let x = 0; x < width; x++) {
-                callback(x, y);
+                callback(x, y, matchedAreas.some(xInArea(x)));
             }
 
             y++;
@@ -75,8 +76,17 @@ const buildDiffImage = (png1, png2, options, callback) => {
     const minHeight = Math.min(png1.height, png2.height);
     const highlightColor = options.highlightColor;
     const result = png.empty(width, height);
+    const ignoreAreas = options.ignoreAreas || [];
+    const ignoredOverlay = options.ignoreColor;
+    const blend = (a, b, k) => {
+        return {
+            R: a.R * k + b.R * (1 - k),
+            G: a.G * k + b.G * (1 - k),
+            B: a.B * k + b.B * (1 - k)
+        };
+    };
 
-    iterateRect(width, height, (x, y) => {
+    iterateRect(width, height, ignoreAreas, (x, y, isIgnored) => {
         if (x >= minWidth || y >= minHeight) {
             result.setPixel(x, y, highlightColor);
             return;
@@ -84,6 +94,11 @@ const buildDiffImage = (png1, png2, options, callback) => {
 
         const color1 = png1.getPixel(x, y);
         const color2 = png2.getPixel(x, y);
+
+        if (isIgnored) {
+            result.setPixel(x, y, blend(ignoredOverlay, blend(color1, color2, 0.5), 0.5));
+            return;
+        }
 
         if (!options.comparator({color1, color2, png1, png2, x, y, width, height})) {
             result.setPixel(x, y, highlightColor);
@@ -94,7 +109,7 @@ const buildDiffImage = (png1, png2, options, callback) => {
 };
 
 const parseColorString = (str) => {
-    const parsed = parseColor(str || '#ff00ff');
+    const parsed = parseColor(str);
 
     return {
         R: parsed.rgb[0],
@@ -160,11 +175,10 @@ module.exports = exports = function looksSame(image1, image2, opts, callback) {
         }
 
         const comparator = createComparator(first, second, opts);
-        const {stopOnFirstFail, shouldCluster, clustersSize} = opts;
+        const {stopOnFirstFail, shouldCluster, clustersSize, ignoreAreas} = opts;
 
-        getDiffPixelsCoords(first, second, comparator, {stopOnFirstFail, shouldCluster, clustersSize}, ({diffArea, diffClusters}) => {
+        getDiffPixelsCoords(first, second, comparator, {stopOnFirstFail, ignoreAreas, shouldCluster, clustersSize}, ({diffArea, diffClusters}) => {
             const diffBounds = diffArea.area;
-
             callback(null, {equal: diffArea.isEmpty(), metaInfo, diffBounds, diffClusters});
         });
     });
@@ -213,7 +227,9 @@ exports.createDiff = function saveDiff(opts, callback) {
         }
 
         const diffOptions = {
-            highlightColor: parseColorString(opts.highlightColor),
+            ignoreAreas: opts.ignoreAreas,
+            ignoreColor: parseColorString(opts.ignoreColor || '#f0ffff'),
+            highlightColor: parseColorString(opts.highlightColor || '#ff00ff'),
             comparator: createComparator(first, second, opts)
         };
 

--- a/index.js
+++ b/index.js
@@ -77,7 +77,6 @@ const buildDiffImage = (png1, png2, options, callback) => {
     const highlightColor = options.highlightColor;
     const result = png.empty(width, height);
     const ignoreAreas = options.ignoreAreas || [];
-    const ignoredOverlay = options.ignoreAreasColor;
     const blend = (a, b, k) => {
         return {
             R: a.R * k + b.R * (1 - k),
@@ -96,7 +95,7 @@ const buildDiffImage = (png1, png2, options, callback) => {
         const color2 = png2.getPixel(x, y);
 
         if (isIgnored) {
-            result.setPixel(x, y, blend(ignoredOverlay, blend(color1, color2, 0.5), 0.5));
+            result.setPixel(x, y, blend(color1, color2, 0.5));
             return;
         }
 
@@ -228,7 +227,6 @@ exports.createDiff = function saveDiff(opts, callback) {
 
         const diffOptions = {
             ignoreAreas: opts.ignoreAreas,
-            ignoreAreasColor: parseColorString(opts.ignoreAreasColor || '#f0ffff'),
             highlightColor: parseColorString(opts.highlightColor || '#ff00ff'),
             comparator: createComparator(first, second, opts)
         };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -41,6 +41,9 @@ const getDiffClusters = (diffClusters, diffArea, {shouldCluster}) => {
     return shouldCluster ? diffClusters.clusters : [diffArea.area];
 };
 
+const yInArea = exports.yInArea = y => area => y >= area.top && y <= area.top + area.height;
+const xInArea = exports.xInArea = x => area => x >= area.left && x <= area.left + area.width;
+
 exports.getDiffPixelsCoords = (png1, png2, predicate, opts, callback) => {
     if (!callback) {
         callback = opts;
@@ -54,10 +57,16 @@ exports.getDiffPixelsCoords = (png1, png2, predicate, opts, callback) => {
 
     const diffArea = new DiffArea();
     const diffClusters = new DiffClusters(opts.clustersSize);
+    const ignoreAreas = opts.ignoreAreas || [];
 
     const processRow = (y) => {
+        const matchedAreas = ignoreAreas.filter(yInArea(y));
+
         setImmediate(() => {
             for (let x = 0; x < width; x++) {
+                if (matchedAreas.some(xInArea(x))) {
+                    continue;
+                }
                 const color1 = png1.getPixel(x, y);
                 const color2 = png2.getPixel(x, y);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -41,8 +41,8 @@ const getDiffClusters = (diffClusters, diffArea, {shouldCluster}) => {
     return shouldCluster ? diffClusters.clusters : [diffArea.area];
 };
 
-const yInArea = exports.yInArea = y => area => y >= area.top && y <= area.top + area.height;
-const xInArea = exports.xInArea = x => area => x >= area.left && x <= area.left + area.width;
+const yInArea = exports.yInArea = (area, y) => y >= area.top && y <= area.top + area.height;
+const xInArea = exports.xInArea = (area, x) => x >= area.left && x <= area.left + area.width;
 
 exports.getDiffPixelsCoords = (png1, png2, predicate, opts, callback) => {
     if (!callback) {
@@ -60,11 +60,11 @@ exports.getDiffPixelsCoords = (png1, png2, predicate, opts, callback) => {
     const ignoreAreas = opts.ignoreAreas || [];
 
     const processRow = (y) => {
-        const matchedAreas = ignoreAreas.filter(yInArea(y));
+        const matchedAreas = ignoreAreas.filter(area => yInArea(area, y));
 
         setImmediate(() => {
             for (let x = 0; x < width; x++) {
-                if (matchedAreas.some(xInArea(x))) {
+                if (matchedAreas.some(area => xInArea(area, x))) {
                     continue;
                 }
                 const color1 = png1.getPixel(x, y);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -60,11 +60,11 @@ exports.getDiffPixelsCoords = (png1, png2, predicate, opts, callback) => {
     const ignoreAreas = opts.ignoreAreas || [];
 
     const processRow = (y) => {
-        const matchedAreas = ignoreAreas.filter(area => yInArea(area, y));
+        const matchedAreas = ignoreAreas.filter((area) => yInArea(area, y));
 
         setImmediate(() => {
             for (let x = 0; x < width; x++) {
-                if (matchedAreas.some(area => xInArea(area, x))) {
+                if (matchedAreas.some((area) => xInArea(area, x))) {
                     continue;
                 }
                 const color1 = png1.getPixel(x, y);

--- a/test/test.js
+++ b/test/test.js
@@ -181,6 +181,102 @@ describe('looksSame', () => {
         });
     });
 
+    describe('ignore areas', () => {
+        forFilesAndBuffers((getImage) => {
+            it('should ignore difference within ignore areas', (done) => {
+                const ignoreAreas = [{
+                    top: 10,
+                    height: 2,
+                    left: 0,
+                    width: 50
+                }];
+
+                looksSame(getImage('ref.png'), getImage('different.png'), {ignoreAreas}, (error, {diffBounds}) => {
+                    expect(diffBounds).to.deep.equal({left: 0, top: 26, right: 49, bottom: 39});
+                    done();
+                });
+            });
+
+            it('should ignore difference within all passed areas', (done) => {
+                const ignoreAreas = [
+                    {
+                        top: 10,
+                        height: 2,
+                        left: 0,
+                        width: 50
+                    },
+                    {
+                        top: 38,
+                        height: 2,
+                        left: 0,
+                        width: 50
+                    }
+                ];
+
+                looksSame(getImage('ref.png'), getImage('different.png'), {ignoreAreas}, (error, {diffBounds}) => {
+                    expect(diffBounds).to.deep.equal({left: 1, top: 26, right: 49, bottom: 27});
+                    done();
+                });
+            });
+
+            it('should return true if all differences are within ignore areas', (done) => {
+                const ignoreAreas = [
+                    {
+                        top: 10,
+                        height: 2,
+                        left: 0,
+                        width: 50
+                    },
+                    {
+                        top: 38,
+                        height: 2,
+                        left: 0,
+                        width: 50
+                    },
+                    {
+                        top: 26,
+                        height: 2,
+                        left: 0,
+                        width: 50
+                    }
+                ];
+
+                looksSame(getImage('ref.png'), getImage('different.png'), {ignoreAreas}, (error, {equal}) => {
+                    expect(equal).to.equal(true);
+                    done();
+                });
+            });
+
+            it('should return correct bounds if difference is partially within ignore area', (done) => {
+                const ignoreAreas = [
+                    {
+                        top: 10,
+                        height: 2,
+                        left: 20,
+                        width: 30
+                    },
+                    {
+                        top: 38,
+                        height: 2,
+                        left: 20,
+                        width: 30
+                    },
+                    {
+                        top: 26,
+                        height: 2,
+                        left: 20,
+                        width: 30
+                    }
+                ];
+
+                looksSame(getImage('ref.png'), getImage('different.png'), {ignoreAreas}, (error, {diffBounds}) => {
+                    expect(diffBounds).to.deep.equal({left: 0, top: 10, right: 19, bottom: 39});
+                    done();
+                });
+            });
+        });
+    });
+
     describe('with comparing by areas', () => {
         forFilesAndBuffers((getImage) => {
             describe('if passed areas have different sizes', () => {


### PR DESCRIPTION
Option `ignoreAreas` for skipping comparision for some areas.
Also a new option `ignoreColor` for createDiff to highlight them.
Usefull in gemini/hermione screenshot assertions, see linked PR's.

https://github.com/gemini-testing/gemini-core/pull/61
https://github.com/gemini-testing/hermione/pull/445