### PR TITLE
fix: functions were modifying input options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,12 +116,13 @@ const getToleranceFromOpts = (opts) => {
 };
 
 const prepareOpts = (opts) => {
-    opts.tolerance = getToleranceFromOpts(opts);
+    const tolerance = getToleranceFromOpts(opts);
 
-    return _.defaults(opts, {
+    return _.defaults({}, opts, {
         ignoreCaret: true,
         ignoreAntialiasing: true,
-        antialiasingTolerance: 0
+        antialiasingTolerance: 0,
+        tolerance: tolerance
     });
 };
 
@@ -228,11 +229,7 @@ exports.createDiff = function saveDiff(opts, callback) {
 };
 
 exports.colors = (color1, color2, opts) => {
-    opts = opts || {};
-
-    if (opts.tolerance === undefined) {
-        opts.tolerance = JND;
-    }
+    opts = _.defaults({}, opts, {tolerance: JND});
 
     const comparator = makeCIEDE2000Comparator(opts.tolerance);
 

--- a/test/test.js
+++ b/test/test.js
@@ -62,6 +62,15 @@ describe('looksSame', () => {
         });
     });
 
+    it('should not modify input options', (done) => {
+        const opts = {};
+
+        looksSame(srcPath('ref.png'), srcPath('same.png'), opts, () => {
+            expect(Object.keys(opts)).to.deep.equal([]);
+            done();
+        });
+    });
+
     forFilesAndBuffers((getImage) => {
         it('should return true for similar images', (done) => {
             looksSame(getImage('ref.png'), getImage('same.png'), (error, {equal}) => {
@@ -396,6 +405,24 @@ describe('createDiff', () => {
                 strict: true
             }, () => {});
         }).to.throw(TypeError);
+    });
+
+    it('should not modify input options', (done) => {
+        const opts = {
+            reference: srcPath('ref.png'),
+            current: srcPath('same.png'),
+            diff: this.tempName,
+            highlightColor: '#ff00ff'
+        };
+
+        looksSame.createDiff(opts, () => {
+            expect(Object.keys(opts)).to.deep.equal(
+                ['reference', 'current', 'diff', 'highlightColor']
+            );
+            done();
+        });
+
+        // If we got here, the call didn't attempt to modify opts
     });
 
     it('should format images', (done) => {
@@ -762,6 +789,17 @@ describe('createDiff', () => {
 });
 
 describe('colors', () => {
+    it('should not modify input options', () => {
+        const opts = {};
+
+        looksSame.colors(
+            {R: 255, G: 0, B: 0},
+            {R: 255, G: 0, B: 0},
+            opts);
+
+        expect(Object.keys(opts)).to.deep.equal([]);
+    });
+
     it('should return true for same colors', () => {
         expect(
             looksSame.colors(


### PR DESCRIPTION
The externally-facing looks-same functions were mutating any `options` object passed into them. 

This was problematic because if you wanted to reuse an options object for multiple calls, it would cause failure.  For example, if you had an options object that simply had `{strict: true}`, then during the first call, looks-same would add a `threshold` property to that, and then complain about the presence of both `strict` and `threshold` on the second call.

This PR adds tests to ensure that the options objects are not mutated, and applies two types of fix:

1. `_.defaults` mutates its first parameter, so add an extra empty `{}` as the initial parameter. This way, we accumulate the results in a _new_ object.  (It would be even simpler to use an object spread but I don't see any in this codebase and it might cause compatibility issues.)
1. Don't assign directly to properties on `opts`, but combine that defaulting with `._defaults` calls.

This fixes issue #41 
