### PR TITLE
fix(prepareOpts): TypeError when opts is undefined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -191,7 +191,7 @@ interface Color {
 declare function looksSame(
     image1: string | Buffer | BoundedImage,
     image2: string | Buffer | BoundedImage,
-    options: LooksSameOptions,
+    options: LooksSameOptions | {},
     callback: LooksSameCallback
 ): void;
 /**

--- a/index.js
+++ b/index.js
@@ -116,6 +116,7 @@ const getToleranceFromOpts = (opts) => {
 };
 
 const prepareOpts = (opts) => {
+    opts = opts || {};
     opts.tolerance = getToleranceFromOpts(opts);
 
     return _.defaults(opts, {

--- a/test/test.js
+++ b/test/test.js
@@ -42,6 +42,12 @@ describe('looksSame', () => {
         }).to.throw(TypeError);
     });
 
+    it('should work when opts is undefined', () => {
+        expect(() => {
+            looksSame(srcPath('ref.png'), srcPath('same.png'), undefined, () => {});
+        }).not.to.throw(TypeError);
+    });
+
     it('should format images', (done) => {
         sandbox.spy(utils, 'formatImages');
 


### PR DESCRIPTION
My tools use lookSame and pass some parameters to this function. 
But sometimes the tools has bugs and passes to lookSame undefined opts, and I get error.
```javascript
Cannot set property 'tolerance' of undefined
```
Because prepareOpts try to set value to `opts.tolerance`, but opts is undefined.

My proposal using empty object by default.