### PR TITLE
chore: update pngjs@6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2427,9 +2427,9 @@
       "dev": true
     },
     "pngjs": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.3.3.tgz",
-      "integrity": "sha512-1n3Z4p3IOxArEs1VRXnZ/RXdfEniAUS9jb68g58FIXMNkPJeZd+Qh4Uq7/e0LVxAQGos1eIUrqrt4FpjdnEd+Q=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="
     },
     "prelude-ls": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lodash": "^4.17.3",
     "nested-error-stacks": "^2.1.0",
     "parse-color": "^1.0.0",
-    "pngjs": "^3.3.3"
+    "pngjs": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^10.12.3",


### PR DESCRIPTION
Update pngjs from 3.3.3 to 6.0.0.
In new version parsing png speed up twice.