### PR TITLE
fix: update node version requirement to 12.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "release": "standard-version"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 12.0.0"
   },
   "author": "Sergey Tatarintsev <sevinf@yandex-team.ru> (https://github.com/SevInf)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "release": "standard-version"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 12.13.0"
   },
   "author": "Sergey Tatarintsev <sevinf@yandex-team.ru> (https://github.com/SevInf)",
   "license": "MIT",


### PR DESCRIPTION
Hi. 
Updated package `pngjs` requires newer version of node

I got error
```
error pngjs@6.0.0: The engine "node" is incompatible with this module. Expected version ">=12.13.0". Got "10.22.1"
error Found incompatible module.
```
during install packages