### PR TITLE
Export types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -192,7 +192,7 @@ declare module looksSame {
      * @param color2 The second color
      * @param options The options passed to looksSame.colors function
      */
-    export function colors(color1: Color, color2: Color, options: { tolerance: number }): void;
+    export function colors(color1: Color, color2: Color, options?: { tolerance: number }): void;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,210 +4,185 @@
 
 /// <reference types="node"/>
 
-/**
- * coordinate bounds
- */
-interface CoordBounds {
-    /**
-     * X-coordinate of upper left corner
-     */
-    left: number;
-    /**
-     * Y-coordinate of upper left corner
-     */
-    top: number;
-    /**
-     * X-coordinate of bottom right corner
-     */
-    right: number;
-    /**
-     * Y-coordinate of bottom right corner
-     */
-    bottom: number;
-}
-
-/**
- * bounded image
- */
-interface BoundedImage {
-    /**
-     * image path or buffer
-     */
-    source: string | Buffer;
-    /**
-     * bounding coordinates
-     */
-    boundingBox: CoordBounds;
-}
-
-/**
- * The result obtained from the function.
-*/
-interface LooksSameResult {
-    /**
-     * true if images are equal, false - otherwise
-     */
-    equal?: boolean;
-    /**
-     * diff bounds for not equal images
-     */
-    diffBounds?: CoordBounds;
-    /**
-     * diff clusters for not equal images
-     */
-    diffClusters?: CoordBounds[];
-}
-
-type LooksSameCallback = (error: Error | null, result: LooksSameResult) => void;
-
-/**
- * The options passed to looksSame function
- */
-interface LooksSameOptions {
-    /**
-     * By default, it will detect only noticeable differences. If you wish to detect any difference, use strict options.
-     */
-    strict?: boolean;
-    /**
-     * You can also adjust the ΔE value that will be treated as error in non-strict mode.
-     */
-    tolerance?: number;
-    /**
-     * Some devices can have different proportion between physical and logical screen resolutions also known as pixel ratio.
-     * Default value for this proportion is 1.
-     * This param also affects the comparison result, so it can be set manually with pixelRatio option.
-     */
-    pixelRatio?: number;
-    /**
-     * Text caret in text input elements it is a pain for visual regression tasks, because it is always blinks.
-     * These diffs will be ignored by default. You can use `ignoreCaret` option with `false` value to disable ignoring such diffs.
-     * In that way text caret will be marked as diffs.
-     */
-    ignoreCaret?: boolean;
-    /**
-     * Some images has difference while comparing because of antialiasing.
-     * These diffs will be ignored by default. You can use ignoreAntialiasing option with false value to disable ignoring such diffs.
-     * In that way antialiased pixels will be marked as diffs.
-     */
-    ignoreAntialiasing?: boolean;
-    /**
-     * Sometimes the antialiasing algorithm can work incorrectly due to some features of the browser rendering engine.
-     * Use the option antialiasingTolerance to make the algorithm less strict.
-     * With this option you can specify the minimum difference in brightness (zero by default)
-     * between the darkest/lightest pixel (which is adjacent to the antialiasing pixel) and theirs adjacent pixels.
-     *
-     * We recommend that you don't increase this value above 10. If you need to increase more than 10 then this is definitely not antialiasing.
-     */
-    antialiasingTolerance?: number;
-    /**
-     * Responsible for diff area which will be returned  when comparing images.
-     * Diff bounds will contain the whole diff if stopOnFirstFail is false and only first diff pixel - otherwise.
-     */
-    stopOnFirstFail?: boolean;
-    /**
-     * Responsible for diff bounds clustering
-     */
-    shouldCluster?: boolean;
-    /**
-     * Radius for every diff cluster
-     */
-    clustersSize?: number;
-}
-
-/**
- * The options passed to looksSame.createDiff function without diff
- */
-interface CreateDiffAsBufferOptions {
-    /**
-     * The baseline image
-     */
-    reference: string | Buffer | BoundedImage;
-    /**
-     * The current image
-     */
-    current: string | Buffer | BoundedImage;
-    /**
-     * Color to highlight the differences
-     * e.g. '#ff00ff'
-     */
-    highlightColor: string;
-    /**
-     * strict comparsion
-     */
-    strict?: boolean;
-    /**
-     * ΔE value that will be treated as error in non-strict mode
-     */
-    tolerance?: number;
-    /**
-     * makes the search algorithm of the antialiasing less strict
-     */
-    antialiasingTolerance?: number;
-    /**
-     * Ability to ignore antialiasing
-     */
-    ignoreAntialiasing?: boolean;
-    /**
-     * Ability to ignore text caret
-     */
-    ignoreCaret?: boolean;
-}
-
-/**
- * The options passed to looksSame.createDiff function
- */
-interface CreateDiffOptions extends CreateDiffAsBufferOptions {
-    /**
-     * The diff image path to store
-     */
-    diff: string;
-}
-
-/**
- * Pass to looksSame.colors function
- */
-interface Color {
-    /**
-     * Red
-     */
-    R: number;
-    /**
-     * Green
-     */
-    G: number;
-    /**
-     * Blue
-     */
-    B: number;
-}
-
-/**
- * Compare two images with options
- * @param image1 The first image
- * @param image2 The second image
- * @param options The options passed to looksSame function
- * @param callback Call when finish compare
- */
-declare function looksSame(
-    image1: string | Buffer | BoundedImage,
-    image2: string | Buffer | BoundedImage,
-    options: LooksSameOptions | {},
-    callback: LooksSameCallback
-): void;
-/**
- * Compare two images
- * @param image1 The first image
- * @param image2 The second image
- * @param callback Call when finish compare
- */
-declare function looksSame(
-    image1: string | Buffer | BoundedImage,
-    image2: string | Buffer | BoundedImage,
-    callback: LooksSameCallback
-): void;
-
 // https://stackoverflow.com/questions/44058101/typescript-declare-third-party-modules
 declare module looksSame {
+    /**
+     * coordinate bounds
+     */
+    export interface CoordBounds {
+        /**
+         * X-coordinate of upper left corner
+         */
+        left: number;
+        /**
+         * Y-coordinate of upper left corner
+         */
+        top: number;
+        /**
+         * X-coordinate of bottom right corner
+         */
+        right: number;
+        /**
+         * Y-coordinate of bottom right corner
+         */
+        bottom: number;
+    }
+
+    /**
+     * bounded image
+     */
+    export interface BoundedImage {
+        /**
+         * image path or buffer
+         */
+        source: string | Buffer;
+        /**
+         * bounding coordinates
+         */
+        boundingBox: CoordBounds;
+    }
+
+    /**
+     * The result obtained from the function.
+    */
+    export interface LooksSameResult {
+        /**
+         * true if images are equal, false - otherwise
+         */
+        equal?: boolean;
+        /**
+         * diff bounds for not equal images
+         */
+        diffBounds?: CoordBounds;
+        /**
+         * diff clusters for not equal images
+         */
+        diffClusters?: CoordBounds[];
+    }
+
+    export type LooksSameCallback = (error: Error | null, result: LooksSameResult) => void;
+
+    /**
+     * The options passed to looksSame function
+     */
+    export interface LooksSameOptions {
+        /**
+         * By default, it will detect only noticeable differences. If you wish to detect any difference, use strict options.
+         */
+        strict?: boolean;
+        /**
+         * You can also adjust the ΔE value that will be treated as error in non-strict mode.
+         */
+        tolerance?: number;
+        /**
+         * Some devices can have different proportion between physical and logical screen resolutions also known as pixel ratio.
+         * Default value for this proportion is 1.
+         * This param also affects the comparison result, so it can be set manually with pixelRatio option.
+         */
+        pixelRatio?: number;
+        /**
+         * Text caret in text input elements it is a pain for visual regression tasks, because it is always blinks.
+         * These diffs will be ignored by default. You can use `ignoreCaret` option with `false` value to disable ignoring such diffs.
+         * In that way text caret will be marked as diffs.
+         */
+        ignoreCaret?: boolean;
+        /**
+         * Some images has difference while comparing because of antialiasing.
+         * These diffs will be ignored by default. You can use ignoreAntialiasing option with false value to disable ignoring such diffs.
+         * In that way antialiased pixels will be marked as diffs.
+         */
+        ignoreAntialiasing?: boolean;
+        /**
+         * Sometimes the antialiasing algorithm can work incorrectly due to some features of the browser rendering engine.
+         * Use the option antialiasingTolerance to make the algorithm less strict.
+         * With this option you can specify the minimum difference in brightness (zero by default)
+         * between the darkest/lightest pixel (which is adjacent to the antialiasing pixel) and theirs adjacent pixels.
+         *
+         * We recommend that you don't increase this value above 10. If you need to increase more than 10 then this is definitely not antialiasing.
+         */
+        antialiasingTolerance?: number;
+        /**
+         * Responsible for diff area which will be returned  when comparing images.
+         * Diff bounds will contain the whole diff if stopOnFirstFail is false and only first diff pixel - otherwise.
+         */
+        stopOnFirstFail?: boolean;
+        /**
+         * Responsible for diff bounds clustering
+         */
+        shouldCluster?: boolean;
+        /**
+         * Radius for every diff cluster
+         */
+        clustersSize?: number;
+    }
+
+    /**
+     * The options passed to looksSame.createDiff function without diff
+     */
+    export interface CreateDiffAsBufferOptions {
+        /**
+         * The baseline image
+         */
+        reference: string | Buffer | BoundedImage;
+        /**
+         * The current image
+         */
+        current: string | Buffer | BoundedImage;
+        /**
+         * Color to highlight the differences
+         * e.g. '#ff00ff'
+         */
+        highlightColor: string;
+        /**
+         * strict comparsion
+         */
+        strict?: boolean;
+        /**
+         * ΔE value that will be treated as error in non-strict mode
+         */
+        tolerance?: number;
+        /**
+         * makes the search algorithm of the antialiasing less strict
+         */
+        antialiasingTolerance?: number;
+        /**
+         * Ability to ignore antialiasing
+         */
+        ignoreAntialiasing?: boolean;
+        /**
+         * Ability to ignore text caret
+         */
+        ignoreCaret?: boolean;
+    }
+
+    /**
+     * The options passed to looksSame.createDiff function
+     */
+    export interface CreateDiffOptions extends CreateDiffAsBufferOptions {
+        /**
+         * The diff image path to store
+         */
+        diff: string;
+    }
+
+    /**
+     * Pass to looksSame.colors function
+     */
+    export interface Color {
+        /**
+         * Red
+         */
+        R: number;
+        /**
+         * Green
+         */
+        G: number;
+        /**
+         * Blue
+         */
+        B: number;
+    }
+
     export function createDiff(options: CreateDiffOptions, callback: (error: Error | null) => any): void;
     export function createDiff(options: CreateDiffAsBufferOptions, callback: (error: Error | null, buffer: Buffer) => any): void;
 
@@ -219,6 +194,31 @@ declare module looksSame {
      */
     export function colors(color1: Color, color2: Color, options: { tolerance: number }): void;
 }
+
+/**
+ * Compare two images with options
+ * @param image1 The first image
+ * @param image2 The second image
+ * @param options The options passed to looksSame function
+ * @param callback Call when finish compare
+ */
+ declare function looksSame(
+    image1: string | Buffer | looksSame.BoundedImage,
+    image2: string | Buffer | looksSame.BoundedImage,
+    options: looksSame.LooksSameOptions | {},
+    callback: looksSame.LooksSameCallback
+): void;
+/**
+ * Compare two images
+ * @param image1 The first image
+ * @param image2 The second image
+ * @param callback Call when finish compare
+ */
+declare function looksSame(
+    image1: string | Buffer | looksSame.BoundedImage,
+    image2: string | Buffer | looksSame.BoundedImage,
+    callback: looksSame.LooksSameCallback
+): void;
 
 /**
  * Node.js library for comparing PNG-images, taking into account human color perception.

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,8 +60,6 @@ declare module looksSame {
         diffClusters?: CoordBounds[];
     }
 
-    export type LooksSameCallback = (error: Error | null, result: LooksSameResult) => void;
-
     /**
      * The options passed to looksSame function
      */
@@ -183,8 +181,8 @@ declare module looksSame {
         B: number;
     }
 
-    export function createDiff(options: CreateDiffOptions, callback: (error: Error | null) => any): void;
-    export function createDiff(options: CreateDiffAsBufferOptions, callback: (error: Error | null, buffer: Buffer) => any): void;
+    export async function createDiff(options: CreateDiffOptions): Promise<null>;
+    export async function createDiff(options: CreateDiffAsBufferOptions): Promise<Buffer>;
 
     /**
      * Compare two colors
@@ -202,12 +200,11 @@ declare module looksSame {
  * @param options The options passed to looksSame function
  * @param callback Call when finish compare
  */
- declare function looksSame(
+ declare async function looksSame(
     image1: string | Buffer | looksSame.BoundedImage,
     image2: string | Buffer | looksSame.BoundedImage,
-    options: looksSame.LooksSameOptions | {},
-    callback: looksSame.LooksSameCallback
-): void;
+    options: looksSame.LooksSameOptions | {}
+): Promise<LooksSameResult>;
 /**
  * Compare two images
  * @param image1 The first image
@@ -216,9 +213,8 @@ declare module looksSame {
  */
 declare function looksSame(
     image1: string | Buffer | looksSame.BoundedImage,
-    image2: string | Buffer | looksSame.BoundedImage,
-    callback: looksSame.LooksSameCallback
-): void;
+    image2: string | Buffer | looksSame.BoundedImage
+): Promise<LooksSameResult>;
 
 /**
  * Node.js library for comparing PNG-images, taking into account human color perception.

--- a/index.d.ts
+++ b/index.d.ts
@@ -239,7 +239,8 @@ declare module looksSame {
      * @param color2 The second color
      * @param options The options passed to looksSame.colors function
      */
-    export function colors(color1: Color, color2: Color, options?: { tolerance: number }): void;
+    export function colors(color1: Color, color2: Color): boolean;
+    export function colors(color1: Color, color2: Color, options: { tolerance: number }): boolean;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,7 @@ declare module looksSame {
          */
         antialiasingTolerance?: number;
         /**
-         * Responsible for diff area which will be returned  when comparing images.
+         * Responsible for diff area which will be returned when comparing images.
          * Diff bounds will contain the whole diff if stopOnFirstFail is false and only first diff pixel - otherwise.
          */
         stopOnFirstFail?: boolean;
@@ -171,7 +171,7 @@ declare module looksSame {
          */
         highlightColor: string;
         /**
-         * strict comparsion
+         * Strict comparsion
          */
         strict?: boolean;
         /**
@@ -179,7 +179,7 @@ declare module looksSame {
          */
         tolerance?: number;
         /**
-         * makes the search algorithm of the antialiasing less strict
+         * Makes the search algorithm of the antialiasing less strict
          */
         antialiasingTolerance?: number;
         /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -114,6 +114,45 @@ declare module looksSame {
         clustersSize?: number;
     }
 
+    export interface GetDiffAreaOptions {
+        /**
+         * Strict comparsion
+         */
+         strict?: boolean;
+         /**
+          * ΔE value that will be treated as error in non-strict mode
+          */
+         tolerance?: number;
+         /**
+          * Some devices can have different proportion between physical and logical screen resolutions also known as pixel ratio.
+          */
+         pixelRatio?: number;
+         /**
+          * Ability to ignore text caret
+          */
+         ignoreCaret?: boolean;
+         /**
+          * Ability to ignore antialiasing
+          */
+         ignoreAntialiasing?: boolean;
+         /**
+          * Makes the search algorithm of the antialiasing less strict
+          */
+         antialiasingTolerance?: number;
+         /**
+          * Responsible for diff area which will be returned when comparing images.
+          */
+         stopOnFirstFail?: boolean;
+         /**
+          * Responsible for diff bounds clustering
+          */
+         shouldCluster?: boolean;
+         /**
+          * Radius for every diff cluster
+          */
+         clustersSize?: number;
+    }
+
     /**
      * The options passed to looksSame.createDiff function without diff
      */
@@ -180,6 +219,16 @@ declare module looksSame {
          */
         B: number;
     }
+
+    export async function getDiffArea(
+        image1: string | Buffer | BoundedImage,
+        image2: string | Buffer | BoundedImage
+    ): Promise<CoordBounds | null>;
+    export async function getDiffArea(
+        image1: string | Buffer | BoundedImage,
+        image2: string | Buffer | BoundedImage,
+        opts: GetDiffAreaOptions
+    ): Promise<CoordBounds | null>;
 
     export async function createDiff(options: CreateDiffOptions): Promise<null>;
     export async function createDiff(options: CreateDiffAsBufferOptions): Promise<Buffer>;


### PR DESCRIPTION
### Что сделано
* экспортировал типы
* исправил тайпинг для метода `colors`, у которого 3-й аргумент на самом деле необязательный, и который возвращает на самом деле `boolean`, а не `void`
* добавил тайпинги для экспортируемой функции `getDiffArea`
* поправил типы после переписывания пакета на `async/await`
* немного поправил описание полей с визуальной стороны