### PR TITLE
feat: Added equal property to the return value when the diff path option is specified.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -525,6 +525,24 @@ describe('createDiff', () => {
         expect(equal).to.be.equal(true);
     });
 
+    it('should return an equal property if the diff path option is specified', async () => {
+        const equalResponse = await looksSame.createDiff({
+            reference: srcPath('ref.png'),
+            current: srcPath('same.png'),
+            diff: this.tempName,
+            highlightColor: '#ff00ff'
+        });
+        const notEqualResponse = await looksSame.createDiff({
+            reference: srcPath('ref.png'),
+            current: srcPath('different.png'),
+            diff: this.tempName,
+            highlightColor: '#ff00ff'
+        });
+
+        expect(equalResponse).to.have.property('equal', true);
+        expect(notEqualResponse).to.have.property('equal', false);
+    });
+
     describe('with comparing by areas', () => {
         it('should create diff image equal to reference', async () => {
             await looksSame.createDiff({


### PR DESCRIPTION
fixes https://github.com/gemini-testing/looks-same/issues/45
If the createDiff function has a diff option as an argument, add equal to the return value option.