### PR TITLE
fix: return diffArea in diffClusters if shouldCluster is false

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -193,6 +193,6 @@ exports.calcDiffImage = async (img1, img2, comparator, {highlightColor, shouldCl
         differentPixels,
         totalPixels,
         diffBounds: diffArea.area,
-        diffClusters: diffClusters.clusters
+        diffClusters: getDiffClusters(diffClusters, diffArea, {shouldCluster})
     };
 };


### PR DESCRIPTION
## Что сделано

Раньше результат `diffClusters` при `shouldCluster: false` и `createDiffImage: true` отличался от `shouldCluster: false` и `createDiffImage: false`.
Теперь `diffClusters` при `shouldCluster: false` и `createDiffImage: true` имеет такой же результат.