### PR TITLE
fix: throw clear error on empty file input

### DIFF
--- a/lib/img-buffer/index.js
+++ b/lib/img-buffer/index.js
@@ -6,6 +6,10 @@ const OriginalBuffer = require('./original-buffer');
 const BoundedBuffer = require('./bounded-buffer');
 
 exports.create = (buffer, {boundingBox} = {}) => {
+    if (buffer.length === 0) {
+        throw new Error('File is empty and cannot be processed as an image');
+    }
+
     return boundingBox
         ? BoundedBuffer.create(buffer, boundingBox)
         : OriginalBuffer.create(buffer);

--- a/test/test.js
+++ b/test/test.js
@@ -39,6 +39,12 @@ describe('looksSame', () => {
         })).to.eventually.be.rejectedWith(TypeError);
     });
 
+    it('should throw when comparing empty files', async () => {
+        const emptyPath = path.join(__dirname, 'data', 'empty.png');
+        await expect(looksSame(emptyPath, emptyPath))
+            .to.eventually.be.rejectedWith(Error, /empty/);
+    });
+
     it('should work when opts is undefined', async () => {
         await expect(looksSame(srcPath('ref.png'), srcPath('same.png')))
             .to.eventually.be.fulfilled;


### PR DESCRIPTION
## Summary

Fixes #117 — comparing an empty file threw a cryptic `RangeError: Attempt to access memory outside buffer bounds`.

### Root cause

The `lib/img-buffer/index.js` `create()` path constructs `OriginalIMGBuffer` which immediately reads PNG width/height via `readUInt32BE()` on a 0-byte buffer. This fast-path check runs before any image decoding.

### Changes

**lib/img-buffer/index.js:**
- Added `buffer.length === 0` guard before constructing buffer objects, throwing a descriptive `Error` instead of letting the RangeError propagate.

**test/test.js:**
- Added test verifying `looksSame` rejects empty files with an error matching `/empty/`.

**test/data/empty.png:**
- Added 0-byte test fixture.

### Before / After

```bash
# Before
RangeError [ERR_BUFFER_OUT_OF_BOUNDS]: Attempt to access memory outside buffer bounds

# After
Error: File is empty and cannot be processed as an image
```