### PR TITLE
fix(index.d.ts): change declare module to declare namespace for tsgo

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@
 /// <reference types="node"/>
 
 // https://stackoverflow.com/questions/44058101/typescript-declare-third-party-modules
-declare module looksSame {
+declare namespace looksSame {
     /**
      * coordinate bounds
      */


### PR DESCRIPTION
## Summary

Fixes #118 — TypeScript 5.8+ (tsgo) rejects `declare module` syntax in ambient `.d.ts` declarations.

```
index.d.ts(8,16): error TS1540: A 'namespace' declaration should not be
declared using the 'module' keyword. Please use the 'namespace' keyword instead.
```

### Changes

**index.d.ts:**
- Changed `declare module looksSame {` to `declare namespace looksSame {` (line 8).

See [microsoft/TypeScript#62876](https://github.com/microsoft/TypeScript/pull/62876),
[microsoft/typescript-go#2760](https://github.com/microsoft/typescript-go/pull/2760).